### PR TITLE
docker-setup: Adding multistage docker build and vscode devcontainer …

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 5.0, 3.1, 2.1
+ARG VARIANT="5.0"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/dotnet
+{
+    "name": "C# (.NET)",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            // Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+            "VARIANT": "5.0",
+        }
+    },
+    // Set *default* container specific settings.json values on container create.
+    "settings": {},
+    "remoteUser": "vscode"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,7 @@ EbayKleinanzeigenCrawler/Properties/PublishProfiles/
 */*.csproj.user
 .vs/
 .vscode/
-TestResults/
-.env
-**/Subscriptions.json
-**/AlreadyProcessedUrls.json
-**/logfile.txt
+.devcontainer/
+**.json
+**.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+EbayKleinanzeigenCrawler/data/
 EbayKleinanzeigenCrawler/obj/
 EbayKleinanzeigenCrawler/bin/
 EbayKleinanzeigenCrawler/Properties/PublishProfiles/
@@ -6,6 +7,6 @@ EbayKleinanzeigenCrawler/Properties/PublishProfiles/
 .vscode/
 TestResults/
 .env
-**/Subscriptions.json
+**/Subscribers.json
 **/AlreadyProcessedUrls.json
 **/logfile.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+WORKDIR /code
+
+COPY . /code
+RUN dotnet restore
+RUN dotnet build -c Release
+
+FROM mcr.microsoft.com/dotnet/runtime:5.0
+WORKDIR /bot
+COPY --from=build /code/EbayKleinanzeigenCrawler/bin/Release/net5.0 .
+RUN chmod +x EbayKleinanzeigenCrawler
+
+ENTRYPOINT ./EbayKleinanzeigenCrawler 
+
+# Note: the environment variable TELEGRAM_BOT_TOKEN has to be set when starting this container
+#       using the --env TELEGRAM_BOT_TOKEN=<TOKEN> syntax

--- a/EbayKleinanzeigenCrawler/Manager/StatefulManagerBase.cs
+++ b/EbayKleinanzeigenCrawler/Manager/StatefulManagerBase.cs
@@ -17,6 +17,8 @@ namespace EbayKleinanzeigenCrawler.Manager
 
         protected StatefulManagerBase(IDataStorage dataStorage, ILogger logger)
         {
+            Directory.CreateDirectory("data");
+            
             DataStorage = dataStorage;
             Logger = logger;
             SubscriberList = new ConcurrentBag<Subscriber<TId>>();
@@ -295,7 +297,7 @@ namespace EbayKleinanzeigenCrawler.Manager
         {
             try
             {
-                DataStorage.Load("Subscribers.json", out ConcurrentBag<Subscriber<TId>> data);
+                DataStorage.Load(Path.Join("data", "Subscribers.json"), out ConcurrentBag<Subscriber<TId>> data);
                 SubscriberList = data;
                 Logger.Information($"Restored data: {data.Count} Subscribers");
             }
@@ -320,7 +322,7 @@ namespace EbayKleinanzeigenCrawler.Manager
 
         private void SaveData()
         {
-            DataStorage.Save(SubscriberList, "Subscribers.json");
+            DataStorage.Save(SubscriberList, Path.Join("data", "Subscribers.json"));
         }
     }
 }

--- a/EbayKleinanzeigenCrawler/Manager/TelegramManager.cs
+++ b/EbayKleinanzeigenCrawler/Manager/TelegramManager.cs
@@ -12,18 +12,20 @@ namespace EbayKleinanzeigenCrawler.Manager
 {
     public class TelegramManager : StatefulManagerBase<long>, IDisposable
     {
-        private const string TelegramBotToken = ""; // TODO: move to config file
+        private readonly string _telegramBotToken;
 
         private readonly ITelegramBotClient _botClient;
 
         public TelegramManager(IDataStorage dataStorage, ILogger logger) : base(dataStorage, logger)
         {
-            if (string.IsNullOrWhiteSpace(TelegramBotToken))
+            this._telegramBotToken = Environment.GetEnvironmentVariable("TELEGRAM_BOT_TOKEN");
+
+            if (string.IsNullOrWhiteSpace(_telegramBotToken))
             {
                 throw new InvalidOperationException("Telegram Bot token was not specified. Please first create a bot and specify its token.");
             }
 
-            _botClient = new TelegramBotClient(TelegramBotToken);
+            _botClient = new TelegramBotClient(_telegramBotToken);
             _botClient.OnMessage += (_, e) => Bot_OnMessage(e);
             _botClient.StartReceiving();
         }

--- a/EbayKleinanzeigenCrawler/Scheduler/JobScheduler.cs
+++ b/EbayKleinanzeigenCrawler/Scheduler/JobScheduler.cs
@@ -61,7 +61,7 @@ namespace EbayKleinanzeigenCrawler.Scheduler
         {
             try
             {
-                _dataStorage.Load("AlreadyProcessedUrls.json", out ConcurrentDictionary<Guid, List<Uri>> data); // TODO: remove URLs for deleted Subscriptions
+                _dataStorage.Load(Path.Join("data", "AlreadyProcessedUrls.json"), out ConcurrentDictionary<Guid, List<Uri>> data); // TODO: remove URLs for deleted Subscriptions
                 _alreadyProcessedUrls = data;
                 _logger.Information($"Restored processed URLs for {data.Count} subscriptions");
             }
@@ -82,7 +82,7 @@ namespace EbayKleinanzeigenCrawler.Scheduler
 
         private void SaveData()
         {
-            _dataStorage.Save(_alreadyProcessedUrls, "AlreadyProcessedUrls.json");
+            _dataStorage.Save(_alreadyProcessedUrls, Path.Join("data", "AlreadyProcessedUrls.json"));
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@
 
 # Before use:
 * Create your own Telegram Bot
-* Paste the Bot's token into "TelegramBotToken" in TelegramManager.cs
+* Set the environment vairable `TELEGRAM_BOT_TOKEN` to your token.
 
 # How to use:
 * Send /help to the Telegram bot for instructions
 * Currently only works with Desktop-Browser links, not mobile browser links. (https://www.ebay-kleinanzeigen.de/....)
 * Ebay Kleinanzeigen obfuscates its HTML with JavaScript, when more than 40 queries are made within the last 5 minutes. This software considers this limit.
 * This software is work in progress. There are many TODOs in the code. Feel free to contribute :-)
+
+# Developing within a VSCode Devcontainer
+* Download the VSCode Extension [Remote Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+* Open the Command Palette via View → Command Palette or using the shortcut `CTRL + SHIFT + P`
+* Run Remote-Containers: Reopen in Container (Rebuild and Reopen at the initial startup)
+* Set the TELEGRAM_BOT_TOKEN environment variable using the syntax `export TELEGRAM_BOT_TOKEN=<TOKEN>`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         build: .
         
         volumes:
-          - ebay-bot-volume:/app
+          - ebay-bot-volume:/bot/data
 
         environment:
             # This variable is taken from the environment. You can use .env-files for this.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
 version: '3'
 
 services:
-    core:
+    ebay-bot:
         restart: always
-        image: mcr.microsoft.com/dotnet/aspnet:5.0
+        build: .
         
         volumes:
-          # Adapt local path
-          - /share/Docker-Volumes/dotnet:/dotnet
-        
-        command: "/bin/sh -c 'while true; cd /dotnet/EbayKleinanzeigenCrawler; chmod +x EbayKleinanzeigenCrawler; ./EbayKleinanzeigenCrawler; do sleep 60;  done'"
+          - ebay-bot-volume:/app
+
+        environment:
+            # This variable is taken from the environment. You can use .env-files for this.
+            TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+
+volumes:
+    ebay-bot-volume:


### PR DESCRIPTION
Developing in their local setup is often an obstacle for developers since runtime environments etc. need to be installed. This PR solves this issue by adding a VSCode devcontainer setup that allows developers to develop within a docker container. Also a multistage docker build was added, since the dotnet image used earlier is unnecessarily large (also changing from aspnet to dotnet core). The final change introduces the usage of an environment variable **TELEGERAM_BOT_TOKEN**. This is way easier to handle than having to add the token in the code.